### PR TITLE
dont use smart pointers to transfer vector data

### DIFF
--- a/bazel/external/wamr.BUILD
+++ b/bazel/external/wamr.BUILD
@@ -13,11 +13,11 @@ filegroup(
 cmake(
     name = "libiwasm",
     cache_entries = {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "On",
         "WAMR_BUILD_AOT": "0",
         "WAMR_BUILD_SIMD": "0",
+        "WAMR_BUILD_MULTI_MODULE": "1",
+        "WAMR_BUILD_LIBC_WASI": "0",
     },
     lib_source = ":srcs",
     out_shared_libs = ["libiwasm.so"],
-    working_directory = "product-mini/platforms/linux"
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -39,8 +39,9 @@ def proxy_wasm_cpp_host_repositories():
     http_archive(
         name = "wamr",
         build_file = "@proxy_wasm_cpp_host//bazel/external:wamr.BUILD",
-        sha256 = "f819b9ec866a12086233e578044dd8297e6be86f0f17807b16124f78a3652d4f",
-        url = "https://github.com/lum1n0us/wasm-micro-runtime/releases/download/WAMR-01-29-2021/source.zip",
+        sha256 = "3f9c993cf81a573cd733b7d97fa15ed757351881e502aad22ff873371ee55202",
+        strip_prefix = "wasm-micro-runtime-0.1-beta",
+        url = "https://github.com/lum1n0us/wasm-micro-runtime/archive/refs/tags/v0.1-beta.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
since `wasm_functype_new` will transfer data ownerships of both `params`
and `resutls` to the new `wasm_functype_t`, we should not
- delete `wasm_valtype_t` of `wasm_valtype_vec_t`
- use `wasm_functype_delete` to release members of `wasm_functype_t`

a good example will be found here:
[multi.c](https://github.com/WebAssembly/wasm-c-api/blob/master/example/multi.c)

another thing is the runtime() should return a string as same as the one in envoy.yaml

update wamr code release to 0.1-beta

Signed-off-by: liam <liang.he@intel.com>